### PR TITLE
Small fix to make SDK path configurable

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -44,7 +44,7 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')
                     ->end()
                 ->end()
-                ->scalarNode('sdk_path')->defaultValue(null)->end()
+                ->scalarNode('sdk_path')->defaultValue('%kernel.root_dir%/../vendor/amazonwebservices/aws-sdk-for-php/sdk.class.php')->end()
                 ->booleanNode('certificate_authority')->defaultFalse()->end()
                 ->booleanNode('disable_auto_config')->defaultFalse()->end()
             ->end();

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -8,7 +8,7 @@
         <parameter key="aws.class">Cybernox\AmazonWebServicesBundle\AmazonWebServices</parameter>
         <parameter key="aws_factory.class">Cybernox\AmazonWebServicesBundle\AmazonWebServicesFactory</parameter>
 
-        <parameter key="cybernox_amazon_web_services.sdk_path">%kernel.root_dir%/../vendor/amazonwebservices/aws-sdk-for-php/sdk.class.php</parameter>
+        <parameter key="cybernox_amazon_web_services.sdk_path" />
     </parameters>
 
     <services>


### PR DESCRIPTION
Hi,

Our `vendor` path isn't in the standard place, so have made a new configuration option `sdk_path`

Thanks for the bundle!
