### PR TITLE
Added check to see if s3 protocol is already registered

### DIFF
--- a/CybernoxAmazonWebServicesBundle.php
+++ b/CybernoxAmazonWebServicesBundle.php
@@ -26,6 +26,10 @@ class CybernoxAmazonWebServicesBundle extends Bundle
     public function boot()
     {
         if (in_array('s3', $this->container->getParameter('cybernox_amazon_web_services.enable_extensions'))) {
+            if (in_array('s3', stream_get_wrappers())) {
+                stream_wrapper_unregister('s3');
+            }
+
             S3StreamWrapper::register($this->container->get('aws_s3'), 's3');
         }
     }


### PR DESCRIPTION
This fixes an issue I was having where in dev environment only the s3 protocol was being registered twice.  It still is, but it no longer chokes on it.

Fixes the following error when clearing cache:

```
Clearing the cache for the dev environment with debug true


  [ErrorException]
  Warning: stream_wrapper_register(): Protocol s3:// is already defined. in {project_dir}\
  trunk\vendor\cybernox\amazon-webservices-bundle\Cybernox\AmazonWebServicesBundle\
  StreamWrapper\S3StreamWrapper.php line 46
```

Error was not occurring in Production mode, or it was failing silently.
