### PR TITLE
Suppress errors on constant definition

### DIFF
--- a/DependencyInjection/CybernoxAmazonWebServicesExtension.php
+++ b/DependencyInjection/CybernoxAmazonWebServicesExtension.php
@@ -37,8 +37,8 @@ class CybernoxAmazonWebServicesExtension extends Extension
             $container->setParameter('cybernox_amazon_web_services.' . $key, $value);
         }
 
-        if ($config['disable_auto_config']) {
-            @define('AWS_DISABLE_CONFIG_AUTO_DISCOVERY', TRUE);
+        if ($config['disable_auto_config'] && (! defined('AWS_DISABLE_CONFIG_AUTO_DISCOVERY'))) {
+            define('AWS_DISABLE_CONFIG_AUTO_DISCOVERY', TRUE);
         }
     }
 }


### PR DESCRIPTION
During deploy to production servers, Composer cycles through multiple times (clearing cache, etc) which causes an error message that the constant is already defined and terminates the Composer scripts.  This update suppresses the error message and allows the script to continue.
