### PR TITLE
Update README.md

### DIFF
--- a/Resources/doc/README.md
+++ b/Resources/doc/README.md
@@ -100,7 +100,7 @@ $loader->registerNamespaces(array(
 ```yml
 // app/config/config.yml
 # Amazon Web Services Configuration
-thephalcons_amazon_web_services:
+the_phalcons_amazon_web_services:
     # for stream wrapper use : [S3, SES ...]
     enable_extensions:              []
     credentials:


### PR DESCRIPTION
Add an underscore between 'the' and 'phalcons'. Without this one I receive the symfony error :  There is no extension able to load the configuration for "thephalcons_amazon_web_services"