### PR TITLE
Fixed dependency on cybermox package

### DIFF
--- a/ThePhalconsAmazonWebServicesBundle.php
+++ b/ThePhalconsAmazonWebServicesBundle.php
@@ -13,7 +13,7 @@
 namespace AmazonWebServicesBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
-use Cybernox\AmazonWebServicesBundle\StreamWrapper\S3StreamWrapper;
+use AmazonWebServicesBundle\StreamWrapper\S3StreamWrapper;
 
 /**
  * AmazonWebServicesBundle Main Bundle Class


### PR DESCRIPTION
Fixed dependency on `Cybermox` that shouldn't be there, the `S3StreamWrapper` appears to have been moved to this project, and you can do this use statement instead:

`use AmazonWebServicesBundle\StreamWrapper\S3StreamWrapper;`